### PR TITLE
adds sortable result columns

### DIFF
--- a/packages/frontend/src/components/EstimationResult.vue
+++ b/packages/frontend/src/components/EstimationResult.vue
@@ -22,15 +22,7 @@
               >Votes</sortable-table-header
             >
           </th>
-          <th class="p-2 w-1/2">
-            <sortable-table-header
-              column="votes"
-              :active-dir="sortDir"
-              :active-col="sortCol"
-              @on-click="sortColumn('votes')"
-              >Voters</sortable-table-header
-            >
-          </th>
+          <th class="p-2 w-1/2">Voters</th>
         </tr>
       </thead>
       <tbody class="bg-gray-200">

--- a/packages/frontend/src/components/EstimationResult.vue
+++ b/packages/frontend/src/components/EstimationResult.vue
@@ -73,14 +73,13 @@ type Entries = Entry[];
 
 const store: Store<State> = useStore();
 const taskName = ref(store.state.estimationResult?.taskName);
+const cardDeck = ref(store.state.cardDeck);
 const sortDir = ref<SortDir>('up');
 const sortCol = ref<SortCol>('size');
+
 const sortFunctions = {
   size: (e1: Entry, e2: Entry): number =>
-    e1.value.localeCompare(e2.value, undefined, {
-      numeric: true,
-      sensitivity: 'base',
-    }),
+    cardDeck.value.indexOf(e1.value) - cardDeck.value.indexOf(e2.value),
   votes: (e1: Entry, e2: Entry): number => (e1.names.length < e2.names.length ? -1 : 1),
 };
 

--- a/packages/frontend/src/components/EstimationResult.vue
+++ b/packages/frontend/src/components/EstimationResult.vue
@@ -62,6 +62,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { Store, useStore } from 'vuex';
+import { useStorage } from '../hooks/useStorage';
 import { State } from '../store/types';
 import ParticipantItem from './ParticipantItem.vue';
 import SortableTableHeader from './SortableTableHeader.vue';
@@ -74,8 +75,11 @@ type Entries = Entry[];
 const store: Store<State> = useStore();
 const taskName = ref(store.state.estimationResult?.taskName);
 const cardDeck = ref(store.state.cardDeck);
-const sortDir = ref<SortDir>('up');
-const sortCol = ref<SortCol>('size');
+
+const storedSortDir = useStorage('sortDir');
+const storedSortCol = useStorage('sortCol');
+const sortDir = ref<SortDir>(storedSortDir.value || 'up');
+const sortCol = ref<SortCol>(storedSortCol.value || 'size');
 
 const sortFunctions = {
   size: (e1: Entry, e2: Entry): number =>
@@ -105,6 +109,9 @@ const sortColumn = (column: SortCol) => {
   } else {
     sortCol.value = column;
   }
+
+  storedSortDir.value = sortDir.value;
+  storedSortCol.value = sortCol.value;
 };
 
 const catUrl = `https://thecatapi.com/api/images/get?format=src&type=gif&nocache=${new Date().toISOString()}`;

--- a/packages/frontend/src/components/EstimationResult.vue
+++ b/packages/frontend/src/components/EstimationResult.vue
@@ -82,7 +82,7 @@ const sortFunctions = {
 
 const sortedEntries = computed((): Entries => {
   return [...estimationResultBySize.value].sort((e1, e2): number => {
-    const dirModifier = sortDir.value === 'down' ? 1 : -1;
+    const dirModifier = sortDir.value === 'down' ? -1 : 1;
     return sortFunctions[sortCol.value](e1, e2) * dirModifier;
   });
 });

--- a/packages/frontend/src/components/EstimationResult.vue
+++ b/packages/frontend/src/components/EstimationResult.vue
@@ -75,6 +75,7 @@ type Entries = Entry[];
 const store: Store<State> = useStore();
 const taskName = ref(store.state.estimationResult?.taskName);
 const cardDeck = ref(store.state.cardDeck);
+const estimationResultBySize = ref<Entries>(store.getters.resultBySize);
 
 const storedSortDir = useStorage('sortDir');
 const storedSortCol = useStorage('sortCol');
@@ -87,16 +88,13 @@ const sortFunctions = {
   votes: (e1: Entry, e2: Entry): number => (e1.names.length < e2.names.length ? -1 : 1),
 };
 
-const estimationResultBySize = ref(
-  store.getters.resultBySize as { value?: string; names: string[] }[]
-);
-
 const sortedEntries = computed((): Entries => {
   return [...estimationResultBySize.value].sort((e1, e2): number => {
     const dirModifier = sortDir.value === 'down' ? 1 : -1;
     return sortFunctions[sortCol.value](e1, e2) * dirModifier;
   });
 });
+
 const showConsensusCats = computed(
   () => store.state.room?.showCats && estimationResultBySize.value.length == 1
 );

--- a/packages/frontend/src/components/SortableTableHeader.vue
+++ b/packages/frontend/src/components/SortableTableHeader.vue
@@ -1,0 +1,34 @@
+<template>
+  <a class="cursor-pointer" :title="linkTooltip" @click="$emit('onClick', column)">
+    <font-awesome-icon v-if="activeCol === column" :icon="`arrow-${activeDir}`" class="mr-2" />
+    <slot></slot>
+  </a>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps({
+  column: {
+    type: String,
+    required: true,
+  },
+  activeDir: {
+    type: String,
+    required: true,
+    validator(value) {
+      return ['up', 'down'].includes(`${value}`);
+    },
+  },
+  activeCol: {
+    type: String,
+    required: true,
+  },
+});
+
+const linkTooltip = computed(
+  () => `Sort column in ${props.activeDir === 'up' ? 'descending' : 'ascending'} order`
+);
+
+defineEmits(['onClick']);
+</script>

--- a/packages/frontend/src/components/SortableTableHeader.vue
+++ b/packages/frontend/src/components/SortableTableHeader.vue
@@ -27,7 +27,7 @@ const props = defineProps({
 });
 
 const linkTooltip = computed(
-  () => `Sort column in ${props.activeDir === 'up' ? 'descending' : 'ascending'} order`
+  () => `Sort column in ${props.activeDir === 'up' ? 'ascending' : 'descending'} order`
 );
 
 defineEmits(['onClick']);

--- a/packages/frontend/src/components/SortableTableHeader.vue
+++ b/packages/frontend/src/components/SortableTableHeader.vue
@@ -27,7 +27,7 @@ const props = defineProps({
 });
 
 const linkTooltip = computed(
-  () => `Sort column in ${props.activeDir === 'up' ? 'ascending' : 'descending'} order`
+  () => `Sort column in ${props.activeDir === 'up' ? 'descending' : 'ascending' } order`
 );
 
 defineEmits(['onClick']);

--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -6,6 +6,8 @@ import {
   faRedo,
   faSlidersH,
   faXmark,
+  faArrowDown,
+  faArrowUp,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { createApp } from 'vue';
@@ -20,5 +22,7 @@ library.add(faPlay);
 library.add(faRedo);
 library.add(faSlidersH);
 library.add(faXmark);
+library.add(faArrowDown);
+library.add(faArrowUp);
 
 createApp(App).use(store).use(router).component('font-awesome-icon', FontAwesomeIcon).mount('#app');

--- a/packages/frontend/tests/unit/EstimationResult.spec.ts
+++ b/packages/frontend/tests/unit/EstimationResult.spec.ts
@@ -1,0 +1,76 @@
+import { VueWrapper, DOMWrapper } from '@vue/test-utils';
+import { describe, expect, it, beforeEach } from 'vitest';
+import EstimationResult from '../../src/components/EstimationResult.vue';
+import {
+  EstimationResult as IEstimationResult,
+  Participant as IParticipant,
+} from '../../src/store/types';
+import createWrapper from './helper';
+
+const estimationResult: IEstimationResult = {
+  taskName: 'test-task',
+  startDate: new Date(),
+  endDate: new Date(),
+  estimates: [
+    { userName: 'Hank', estimate: '2' },
+    { userName: 'Jessie', estimate: '18' },
+    { userName: 'Walter', estimate: '10' },
+    { userName: 'Saul', estimate: '10' },
+  ],
+};
+
+const participants: IParticipant[] = [
+  { name: 'Hank', isSpectator: false, hasEstimated: true },
+  { name: 'Jessie', isSpectator: false, hasEstimated: true },
+  { name: 'Walter', isSpectator: false, hasEstimated: true },
+  { name: 'Saul', isSpectator: false, hasEstimated: true },
+];
+
+let wrapper: VueWrapper;
+let tableHeaders: DOMWrapper<Element>[];
+
+describe('estimation result', () => {
+  beforeEach(() => {
+    wrapper = createWrapper(
+      EstimationResult,
+      {},
+      {
+        estimationResult,
+        cardDeck: ['0, 1, 2, 3, 5, 8, 10, 13, 18'],
+        participants,
+      }
+    ).wrapper;
+
+    tableHeaders = wrapper.findAll('thead a');
+  });
+
+  it('should sort estimations according to their job-size', async () => {
+    const estimationRows = wrapper.findAll('tbody > tr').map(tr => tr.text());
+
+    expect(estimationRows[0]).toContain('Jessie');
+    expect(estimationRows[1]).toContain('Saul');
+    expect(estimationRows[1]).toContain('Walter');
+    expect(estimationRows[2]).toContain('Hank');
+  });
+
+  it('should sort estimations according to their voters count DESC on click', async () => {
+    await tableHeaders[1].trigger('click');
+    const estimationRows = wrapper.findAll('tbody > tr').map(tr => tr.text());
+
+    expect(estimationRows[0]).toContain('Walter');
+    expect(estimationRows[0]).toContain('Saul');
+    expect(estimationRows[1]).toContain('Jessie');
+    expect(estimationRows[2]).toContain('Hank');
+  });
+
+  it('should sort estimations according to their voters count ASC on double click', async () => {
+    await tableHeaders[1].trigger('click');
+    await tableHeaders[1].trigger('click');
+    const estimationRows = wrapper.findAll('tbody > tr').map(tr => tr.text());
+
+    expect(estimationRows[0]).toContain('Hank');
+    expect(estimationRows[1]).toContain('Jessie');
+    expect(estimationRows[2]).toContain('Walter');
+    expect(estimationRows[2]).toContain('Saul');
+  });
+});

--- a/packages/frontend/tests/unit/EstimationResult.spec.ts
+++ b/packages/frontend/tests/unit/EstimationResult.spec.ts
@@ -1,5 +1,5 @@
 import { VueWrapper, DOMWrapper } from '@vue/test-utils';
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import EstimationResult from '../../src/components/EstimationResult.vue';
 import {
   EstimationResult as IEstimationResult,
@@ -42,6 +42,10 @@ describe('estimation result with numerical job-sizes', () => {
     ).wrapper;
 
     tableHeaders = wrapper.findAll('thead a');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
   });
 
   it('should sort estimations according to their job-size', async () => {

--- a/packages/frontend/tests/unit/EstimationResult.spec.ts
+++ b/packages/frontend/tests/unit/EstimationResult.spec.ts
@@ -7,18 +7,6 @@ import {
 } from '../../src/store/types';
 import createWrapper from './helper';
 
-const estimationResult: IEstimationResult = {
-  taskName: 'test-task',
-  startDate: new Date(),
-  endDate: new Date(),
-  estimates: [
-    { userName: 'Hank', estimate: '2' },
-    { userName: 'Jessie', estimate: '18' },
-    { userName: 'Walter', estimate: '10' },
-    { userName: 'Saul', estimate: '10' },
-  ],
-};
-
 const participants: IParticipant[] = [
   { name: 'Hank', isSpectator: false, hasEstimated: true },
   { name: 'Jessie', isSpectator: false, hasEstimated: true },
@@ -29,14 +17,26 @@ const participants: IParticipant[] = [
 let wrapper: VueWrapper;
 let tableHeaders: DOMWrapper<Element>[];
 
-describe('estimation result', () => {
+describe('estimation result with numerical job-sizes', () => {
+  const estimationResult: IEstimationResult = {
+    taskName: 'test-task',
+    startDate: new Date(),
+    endDate: new Date(),
+    estimates: [
+      { userName: 'Hank', estimate: '2' },
+      { userName: 'Jessie', estimate: '18' },
+      { userName: 'Walter', estimate: '10' },
+      { userName: 'Saul', estimate: '10' },
+    ],
+  };
+
   beforeEach(() => {
     wrapper = createWrapper(
       EstimationResult,
       {},
       {
         estimationResult,
-        cardDeck: ['0, 1, 2, 3, 5, 8, 10, 13, 18'],
+        cardDeck: ['0', '1', '2', '3', '5', '8', '10', '13', '18'],
         participants,
       }
     ).wrapper;
@@ -72,5 +72,42 @@ describe('estimation result', () => {
     expect(estimationRows[1]).toContain('Jessie');
     expect(estimationRows[2]).toContain('Walter');
     expect(estimationRows[2]).toContain('Saul');
+  });
+});
+
+describe('estimation result with custom job-sizes', () => {
+  const estimationResult: IEstimationResult = {
+    taskName: 'test-task',
+    startDate: new Date(),
+    endDate: new Date(),
+    estimates: [
+      { userName: 'Hank', estimate: 'L' },
+      { userName: 'Jessie', estimate: 'XS' },
+      { userName: 'Walter', estimate: 'XL' },
+      { userName: 'Saul', estimate: 'XL' },
+    ],
+  };
+
+  beforeEach(() => {
+    wrapper = createWrapper(
+      EstimationResult,
+      {},
+      {
+        estimationResult,
+        cardDeck: ['XS', 'S', 'M', 'L', 'XL'],
+        participants,
+      }
+    ).wrapper;
+
+    tableHeaders = wrapper.findAll('thead a');
+  });
+
+  it('should sort estimations according to their job-size', async () => {
+    const estimationRows = wrapper.findAll('tbody > tr').map(tr => tr.text());
+
+    expect(estimationRows[0]).toContain('Walter');
+    expect(estimationRows[0]).toContain('Saul');
+    expect(estimationRows[1]).toContain('Hank');
+    expect(estimationRows[2]).toContain('Jessie');
   });
 });

--- a/packages/frontend/tests/unit/EstimationResult.spec.ts
+++ b/packages/frontend/tests/unit/EstimationResult.spec.ts
@@ -51,24 +51,13 @@ describe('estimation result with numerical job-sizes', () => {
   it('should sort estimations according to their job-size', async () => {
     const estimationRows = wrapper.findAll('tbody > tr').map(tr => tr.text());
 
-    expect(estimationRows[0]).toContain('Jessie');
+    expect(estimationRows[0]).toContain('Hank');
     expect(estimationRows[1]).toContain('Saul');
     expect(estimationRows[1]).toContain('Walter');
-    expect(estimationRows[2]).toContain('Hank');
+    expect(estimationRows[2]).toContain('Jessie');
   });
 
   it('should sort estimations according to their voters count DESC on click', async () => {
-    await tableHeaders[1].trigger('click');
-    const estimationRows = wrapper.findAll('tbody > tr').map(tr => tr.text());
-
-    expect(estimationRows[0]).toContain('Walter');
-    expect(estimationRows[0]).toContain('Saul');
-    expect(estimationRows[1]).toContain('Jessie');
-    expect(estimationRows[2]).toContain('Hank');
-  });
-
-  it('should sort estimations according to their voters count ASC on double click', async () => {
-    await tableHeaders[1].trigger('click');
     await tableHeaders[1].trigger('click');
     const estimationRows = wrapper.findAll('tbody > tr').map(tr => tr.text());
 
@@ -76,6 +65,17 @@ describe('estimation result with numerical job-sizes', () => {
     expect(estimationRows[1]).toContain('Jessie');
     expect(estimationRows[2]).toContain('Walter');
     expect(estimationRows[2]).toContain('Saul');
+  });
+
+  it('should sort estimations according to their voters count ASC on double click', async () => {
+    await tableHeaders[1].trigger('click');
+    await tableHeaders[1].trigger('click');
+    const estimationRows = wrapper.findAll('tbody > tr').map(tr => tr.text());
+
+    expect(estimationRows[0]).toContain('Walter');
+    expect(estimationRows[0]).toContain('Saul');
+    expect(estimationRows[1]).toContain('Jessie');
+    expect(estimationRows[2]).toContain('Hank');
   });
 });
 
@@ -109,9 +109,9 @@ describe('estimation result with custom job-sizes', () => {
   it('should sort estimations according to their job-size', async () => {
     const estimationRows = wrapper.findAll('tbody > tr').map(tr => tr.text());
 
-    expect(estimationRows[0]).toContain('Walter');
-    expect(estimationRows[0]).toContain('Saul');
+    expect(estimationRows[0]).toContain('Jessie');
     expect(estimationRows[1]).toContain('Hank');
-    expect(estimationRows[2]).toContain('Jessie');
+    expect(estimationRows[2]).toContain('Walter');
+    expect(estimationRows[2]).toContain('Saul');
   });
 });


### PR DESCRIPTION
This PR adds sortable columns on the result page. Clicking the table headers will sort the columns accordingly. Clicking again will reverse the sorting order.