### PR TITLE
Handle duplicate users

### DIFF
--- a/packages/backend/src/__features__/Estimation.feature
+++ b/packages/backend/src/__features__/Estimation.feature
@@ -33,7 +33,7 @@ Feature: Performing estimations
     Given there is a room with an ongoing estimation for "Buy milk"
     And "John" estimated "1"
     And "Jimmy" estimated "13"
-    When a participant named "Fred" joins the room
+    When a participant named "Fredrich" joins the room
     Then he should receive information about the task
     And he should receive information about who has already estimated
 

--- a/packages/backend/src/__features__/JoiningAndLeaving.feature
+++ b/packages/backend/src/__features__/JoiningAndLeaving.feature
@@ -12,6 +12,12 @@ Feature: Joining and leaving poker room
     And he should receive information about the existing participants
     And the existing participants should be informed about the new participant
 
+  Scenario: Joining a room with existing user-name
+    Given there is a room with a participant named "Fred"
+    When a participant named "Fred" joins the room
+    Then the new participant should be renamed to "Fred (1)"
+    And the participant himself should be informed about the user-name change
+
   Scenario: Leaving a room
     Given there is a room with a few participants
     When a participant named "Fred" leaves the room

--- a/packages/backend/src/__features__/support/joiningAndLeavingSteps.ts
+++ b/packages/backend/src/__features__/support/joiningAndLeavingSteps.ts
@@ -28,6 +28,14 @@ Given('there is a room with a few participants', function () {
   };
 });
 
+Given('there is a room with a participant named {string}', function (userName: string) {
+  this.room = {
+    name: ROOM_NAME,
+    participants: [buildParticipant(userName)],
+    cardDeck: ['0', '1', '2', '3', '5', '8', '13', '20', '40', '100', '???'],
+  };
+});
+
 When('a participant named {string} joins the room', function (userName: string) {
   this.inputEvent = {
     eventType: 'joinRoom',
@@ -144,5 +152,38 @@ Then('the remaining participants should be informed the leaving participant', fu
   expect(this.outgoingCommands).toContainEqual({
     type: CommandType.BROADCAST_MESSAGE,
     payload: this.inputEvent,
+  });
+});
+
+Then('the new participant should be renamed to {string}', function (userName: string) {
+  const userJoinedEvent: UserJoined = {
+    eventType: 'userJoined',
+    userName,
+    isSpectator: this.newParticipant!.isSpectator,
+  };
+
+  this.changedUsername = userName;
+
+  expect(this.outgoingCommands).toContainEqual({
+    type: CommandType.BROADCAST_MESSAGE,
+    payload: userJoinedEvent,
+  });
+});
+
+Then('the participant himself should be informed about the user-name change', function () {
+  const userRenamedEvent: UserRenamed = {
+    eventType: 'userRenamed',
+    userName: this.changedUsername,
+  };
+
+  const recipient = {
+    ...this.newParticipant,
+    name: this.changedUsername,
+  };
+
+  expect(this.outgoingCommands).toContainEqual({
+    type: CommandType.SEND_MESSAGE,
+    payload: [userRenamedEvent],
+    recipient,
   });
 });

--- a/packages/backend/src/domain/pokerEvents.ts
+++ b/packages/backend/src/domain/pokerEvents.ts
@@ -8,7 +8,8 @@ type PokerEvent =
   | UserEstimate
   | UserHasEstimated
   | RequestShowEstimationResult
-  | EstimationResult;
+  | EstimationResult
+  | UserRenamed;
 
 interface JoinRoom {
   eventType: 'joinRoom';
@@ -37,6 +38,11 @@ interface UserRemoved {
 interface ChangeCardDeck {
   eventType: 'changeCardDeck';
   cardDeck: string[];
+}
+
+interface UserRenamed {
+  eventType: 'userRenamed';
+  userName: string;
 }
 
 interface StartEstimation {

--- a/packages/backend/src/helpers/uniqueName.ts
+++ b/packages/backend/src/helpers/uniqueName.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns an incremented version if a string already exists
+ *
+ * @example
+ * If the name already exists in the given collection, it adds a counter to the name
+ * ```ts
+ * uniqueName('Petra', ['Petra', 'Frank']) // returns 'Petra (1)'
+ * ```
+ */
+export default (name: string, existingNames: string[]): string => {
+  const regex = new RegExp(`^(${name}\\s\\(\\d\\)|${name})$`);
+  const matches = existingNames.filter(existName => existName.match(regex));
+  return matches.length ? `${name} (${matches.length})` : name;
+};

--- a/packages/frontend/src/components/EstimationResult.vue
+++ b/packages/frontend/src/components/EstimationResult.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, toRef } from 'vue';
 import { Store, useStore } from 'vuex';
 import { useStorage } from '../hooks/useStorage';
 import { State } from '../store/types';
@@ -67,7 +67,7 @@ type Entries = Entry[];
 const store: Store<State> = useStore();
 const taskName = ref(store.state.estimationResult?.taskName);
 const cardDeck = ref(store.state.cardDeck);
-const estimationResultBySize = ref<Entries>(store.getters.resultBySize);
+const estimationResultBySize = toRef(store.getters, 'resultBySize');
 
 const storedSortDir = useStorage('sortDir');
 const storedSortCol = useStorage('sortCol');

--- a/packages/frontend/src/components/SortableTableHeader.vue
+++ b/packages/frontend/src/components/SortableTableHeader.vue
@@ -27,7 +27,7 @@ const props = defineProps({
 });
 
 const linkTooltip = computed(
-  () => `Sort column in ${props.activeDir === 'up' ? 'descending' : 'ascending' } order`
+  () => `Sort column in ${props.activeDir === 'up' ? 'descending' : 'ascending'} order`
 );
 
 defineEmits(['onClick']);

--- a/packages/frontend/src/hooks/useModel.ts
+++ b/packages/frontend/src/hooks/useModel.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue';
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function useModel(props: { [key: string]: any }, emit: Function, name = 'modelValue') {
+export function useModel(props: { [key: string]: unknown }, emit: Function, name = 'modelValue') {
   return computed({
     get: () => props[name],
     set: value => emit(`update:${name}`, value),

--- a/packages/frontend/src/store/index.ts
+++ b/packages/frontend/src/store/index.ts
@@ -51,7 +51,7 @@ export type Store = Omit<VuexStore<State>, 'getters' | 'commit' | 'dispatch'> & 
   };
 };
 
-export const customStore = (options: { [key: string]: any }) => {
+export const customStore = (options: State) => {
   const customOptions = { ...defaultOptions };
   customOptions.state = { ...customOptions.state, ...options };
   return createStore<State>(customOptions);

--- a/packages/frontend/src/store/mutations.spec.ts
+++ b/packages/frontend/src/store/mutations.spec.ts
@@ -97,7 +97,7 @@ describe('mutations', () => {
     expect(state.participants).toEqual([exampleParticipant]);
   });
 
-  it('removes participants when they leave', () => {
+  describe('when a user leaves', () => {
     const state: State = {
       ...initialState,
       participants: [exampleParticipant, { ...exampleParticipant, name: 'Bar' }],
@@ -108,9 +108,49 @@ describe('mutations', () => {
       userName: 'Bar',
     };
 
-    mutations.userLeft(state, userLeft);
+    it('should be removed from participants list', () => {
+      const testState = { ...state };
+      mutations.userLeft(testState, userLeft);
+      expect(testState.participants).toEqual([exampleParticipant]);
+    });
 
-    expect(state.participants).toEqual([exampleParticipant]);
+    it('should remove pending vote', () => {
+      const testState = {
+        ...state,
+        estimationResult: {
+          taskName: 'Some old task',
+          startDate: new Date(),
+          endDate: new Date(),
+          estimates: [
+            { userName: 'Bar', estimate: undefined },
+            { userName: 'Foo', estimate: 'O' },
+          ],
+        },
+      };
+      mutations.userLeft(testState, userLeft);
+      expect(testState.estimationResult?.estimates).not.toContain({
+        userName: 'Bar',
+        estimate: undefined,
+      });
+    });
+
+    it('should not remove active vote', () => {
+      const estimates = [
+        { userName: 'Bar', estimate: 'N' },
+        { userName: 'Foo', estimate: 'O' },
+      ];
+      const testState = {
+        ...state,
+        estimationResult: {
+          taskName: 'Some old task',
+          startDate: new Date(),
+          endDate: new Date(),
+          estimates,
+        },
+      };
+      mutations.userLeft(testState, userLeft);
+      expect(testState.estimationResult?.estimates).toEqual(estimates);
+    });
   });
 
   it('prepares state if a new estimation is initiated', () => {

--- a/packages/frontend/src/store/mutations.ts
+++ b/packages/frontend/src/store/mutations.ts
@@ -7,7 +7,7 @@ import {
   UserJoined,
   UserLeft,
 } from '../store/pokerEvents';
-import { State, RoomInformation } from '../store/types';
+import { State, RoomInformation, EstimationResult as StoreEstimationResult } from '../store/types';
 
 export enum MutationsType {
   SET_ROOM_INFORMATION = 'setRoomInformation',
@@ -29,6 +29,16 @@ export type Mutations = {
   [MutationsType.START_ESTIMATION](state: State, event: StartEstimation): void;
   [MutationsType.USER_HAS_ESTIMATED](state: State, event: UserHasEstimated): void;
   [MutationsType.ESTIMATION_RESULT](state: State, event: EstimationResult): void;
+};
+
+const removePendingUserEstimation = (
+  userName: string,
+  estimationResult: StoreEstimationResult
+): StoreEstimationResult => {
+  const estimates = estimationResult.estimates.filter(
+    userEstimate => userEstimate.userName !== userName || userEstimate.estimate
+  );
+  return { ...estimationResult, estimates };
 };
 
 export const mutations: MutationTree<State> & Mutations = {
@@ -58,6 +68,10 @@ export const mutations: MutationTree<State> & Mutations = {
   },
   [MutationsType.USER_LEFT](state: State, event: UserLeft) {
     state.participants = state.participants.filter(p => p.name != event.userName);
+
+    if (state.estimationResult) {
+      state.estimationResult = removePendingUserEstimation(event.userName, state.estimationResult);
+    }
   },
   [MutationsType.CHANGE_CARD_DECK](state: State, event: ChangeCardDeck) {
     state.cardDeck = event.cardDeck;

--- a/packages/frontend/src/store/mutations.ts
+++ b/packages/frontend/src/store/mutations.ts
@@ -7,6 +7,7 @@ import {
   UserHasEstimated,
   UserJoined,
   UserLeft,
+  UserRenamed,
 } from '../store/pokerEvents';
 import { State, RoomInformation, EstimationResult as StoreEstimationResult } from '../store/types';
 
@@ -15,6 +16,7 @@ export enum MutationsType {
   LEAVE_ROOM = 'leaveRoom',
   USER_JOINED = 'userJoined',
   USER_LEFT = 'userLeft',
+  USER_RENAMED = 'userRenamed',
   CHANGE_CARD_DECK = 'changeCardDeck',
   START_ESTIMATION = 'startEstimation',
   USER_HAS_ESTIMATED = 'userHasEstimated',
@@ -26,6 +28,7 @@ export type Mutations = {
   [MutationsType.LEAVE_ROOM](state: State): void;
   [MutationsType.USER_JOINED](state: State, event: UserJoined): void;
   [MutationsType.USER_LEFT](state: State, event: UserLeft): void;
+  [MutationsType.USER_RENAMED](state: State, event: UserRenamed): void;
   [MutationsType.CHANGE_CARD_DECK](state: State, event: ChangeCardDeck): void;
   [MutationsType.START_ESTIMATION](state: State, event: StartEstimation): void;
   [MutationsType.USER_HAS_ESTIMATED](state: State, event: UserHasEstimated): void;
@@ -75,6 +78,14 @@ export const mutations: MutationTree<State> & Mutations = {
 
     if (state.estimationResult) {
       state.estimationResult = removePendingUserEstimation(event.userName, state.estimationResult);
+    }
+  },
+  [MutationsType.USER_RENAMED](state: State, event: UserRenamed) {
+    if (state.room) {
+      state.room = {
+        ...state.room,
+        userName: event.userName,
+      };
     }
   },
   [MutationsType.CHANGE_CARD_DECK](state: State, event: ChangeCardDeck) {

--- a/packages/frontend/src/store/pokerEvents.ts
+++ b/packages/frontend/src/store/pokerEvents.ts
@@ -9,6 +9,7 @@ export type PokerEvent =
   | UserJoined
   | UserLeft
   | RemoveUser
+  | UserRenamed
   | ChangeCardDeck
   | StartEstimation
   | UserEstimate
@@ -38,6 +39,10 @@ export interface RemoveUser {
   eventType: 'removeUser';
   userName: string;
   roomName: string;
+}
+export interface UserRenamed {
+  eventType: 'userRenamed';
+  userName: string;
 }
 
 export interface ChangeCardDeck {

--- a/packages/frontend/src/store/types.ts
+++ b/packages/frontend/src/store/types.ts
@@ -33,5 +33,5 @@ export interface EstimationResult {
 
 export interface Estimate {
   userName: string;
-  estimate: string;
+  estimate?: string;
 }

--- a/packages/frontend/src/store/websocketPlugin.ts
+++ b/packages/frontend/src/store/websocketPlugin.ts
@@ -31,6 +31,7 @@ const webSocketPlugin = (store: Store<State>) => {
     switch (message.eventType) {
       case 'userJoined':
       case 'userLeft':
+      case 'userRenamed':
       case 'changeCardDeck':
       case 'startEstimation':
       case 'userHasEstimated':


### PR DESCRIPTION
- Duplicate user-names will be added a (1) to avoid conflicts
- Left (or removed) users are also removed from result list, if they did not estimate


Also Solves: https://github.com/Planning-Poker-Teams/planning-poker/issues/24