### PR TITLE
fix(frontend): show consensus cats during vote correction

### DIFF
--- a/packages/frontend/src/components/EstimationResult.vue
+++ b/packages/frontend/src/components/EstimationResult.vue
@@ -125,14 +125,9 @@ const sortedEntries = computed((): Entries => {
 });
 
 const showConsensusCats = computed(
-  () =>
-    store.state.room?.showCats &&
-    estimationResultBySize.value.length == 1 &&
-    !store.state.estimationResult?.isEditable
+  () => store.state.room?.showCats && estimationResultBySize.value.length == 1
 );
-const consensusReached = computed(
-  () => estimationResultBySize.value.length == 1 && !store.state.estimationResult?.isEditable
-);
+const consensusReached = computed(() => estimationResultBySize.value.length == 1);
 
 const hasVoted = (vote?: string): boolean => typeof vote !== 'undefined';
 


### PR DESCRIPTION
The consensus message and cat GIF were gated on `!isEditable`, but with vote correction enabled the result stays editable for the entire correction window, so consensus was never detected. Detect consensus by vote agreement alone, regardless of editability.